### PR TITLE
Use explicit `contents: read` workflow permissions where applicable

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '15 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rather than falling back to repository-wide GHA permissions, which is less clear and also may be less secure if they are greater than necessary.